### PR TITLE
fix: NPE when agentstream can't access

### DIFF
--- a/src/main/java/org/skywalking/apm/ui/tools/CollectorUIServerGetterTimer.java
+++ b/src/main/java/org/skywalking/apm/ui/tools/CollectorUIServerGetterTimer.java
@@ -72,7 +72,7 @@ public enum CollectorUIServerGetterTimer {
                 logger.debug("uiServerResponse: %s", uiServerResponse);
                 JsonArray serverArray = gson.fromJson(uiServerResponse, JsonArray.class);
                 if (serverArray == null || serverArray.size() == 0) {
-                    logger.info("emtry grpc server array, skip : %s", server);
+                    logger.warn("emtry grpc server array, skip : %s", server);
                     continue;
                 }
                 List<String> servers = new ArrayList<>();
@@ -82,7 +82,7 @@ public enum CollectorUIServerGetterTimer {
                 logger.error(e.getMessage(), e);
             }
         }
-        logger.debug("none agentstream server return available grpc server.");
+        logger.warn("none agentstream server return available grpc server.");
         return null;
     }
 }

--- a/src/main/java/org/skywalking/apm/ui/tools/CollectorUIServerGetterTimer.java
+++ b/src/main/java/org/skywalking/apm/ui/tools/CollectorUIServerGetterTimer.java
@@ -71,6 +71,10 @@ public enum CollectorUIServerGetterTimer {
                 String uiServerResponse = HttpClientTools.INSTANCE.get("http://" + server + "/ui/jetty", null);
                 logger.debug("uiServerResponse: %s", uiServerResponse);
                 JsonArray serverArray = gson.fromJson(uiServerResponse, JsonArray.class);
+                if (serverArray == null || serverArray.size() == 0) {
+                    logger.info("emtry grpc server array, skip : %s", server);
+                    continue;
+                }
                 List<String> servers = new ArrayList<>();
                 serverArray.forEach(serverElement -> servers.add(serverElement.getAsString()));
                 return servers;
@@ -78,6 +82,7 @@ public enum CollectorUIServerGetterTimer {
                 logger.error(e.getMessage(), e);
             }
         }
+        logger.debug("none agentstream server return available grpc server.");
         return null;
     }
 }

--- a/src/main/java/org/skywalking/apm/ui/tools/HttpClientTools.java
+++ b/src/main/java/org/skywalking/apm/ui/tools/HttpClientTools.java
@@ -63,12 +63,12 @@ public enum HttpClientTools {
                 }
             }
         } catch (Exception e) {
-            logger.debug("bad url="+url, e);
+            logger.warn("bad url="+url, e);
         } finally {
             try {
                 httpClient.close();
             } catch (IOException e) {
-                logger.debug("bad url="+url, e);
+                logger.warn("bad url="+url, e);
             }
         }
         return null;

--- a/src/main/java/org/skywalking/apm/ui/tools/HttpClientTools.java
+++ b/src/main/java/org/skywalking/apm/ui/tools/HttpClientTools.java
@@ -63,12 +63,12 @@ public enum HttpClientTools {
                 }
             }
         } catch (Exception e) {
-            e.printStackTrace();
+            logger.debug("bad url="+url, e);
         } finally {
             try {
                 httpClient.close();
             } catch (IOException e) {
-                e.printStackTrace();
+                logger.debug("bad url="+url, e);
             }
         }
         return null;


### PR DESCRIPTION
当配置文件里面的agentstream配置的地址无法访问, CollectorUIServerGetterTimer就循环抛NPE, 让人摸不着头脑